### PR TITLE
Update autoplay.noUpdate.user.js

### DIFF
--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -836,7 +836,7 @@ function useAbilitiesAt100() {
 				return;
 			}
 			if (bHaveItem(ABILITIES.WORMHOLE)) triggerAbility(ABILITIES.WORMHOLE); //wormhole
-		}, 100);
+		}, 1000); //SLOW DOWN. 100ms trigger is causing server to ignore client, primary cause of client desync.
 	}
 	
 	//This should equate to approximately 1.8 Like News per second


### PR DESCRIPTION
SLOW DOWN on WH spam on the 100 level. Yes it gives HUGE jumps however the blowback is many fewer jump opportunities as everyone is desync'd. 100ms trigger is clearly causing server to ignore client, primary cause of client desync. I'm seeing this in rm#3.
